### PR TITLE
Issues/13 change skip declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Test `skip` declaration. Moved from: 
+  ```
+  describe('description', { skip: true }, () => {})
+  //or
+  test('description', { skip: true }, () => {})
+  ```
+  to:
+  ```
+  describe.skip('description', () => {})
+  //or
+  test.skip('description', () => {})
+  ```
+- Updated documentation
+
 ## 1.0.2 - 2025-05-19
 ### Fixed
 - Fixed `toBeEqual()` assertion to output types as well as value

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-<b>ScripterI/O - Simple, fast, runner for testing all JavaScript</b>
+<b>ScripterI/O - Simple, fast, ESM runner for testing all JavaScript</b>
 </p>
 
 <p align="center">
@@ -43,7 +43,8 @@ Use the `test` function to write test cases and the `describe` function to group
 
 More example:
 
-https://github.com/VadimNastoyashchy/scripterio-boilerplate-project
+- https://github.com/VadimNastoyashchy/scripterio-boilerplate-project
+- https://github.com/VadimNastoyashchy/json-mcp
 
 Let's start by creating the `test.js` test file.
 
@@ -55,7 +56,7 @@ Let's start by creating the `test.js` test file.
 
 test.js
 
-```
+```js
 import { describe, test, expect} from 'scripterio'
 
 describe('Title for describe block', () => {
@@ -107,7 +108,7 @@ Use `expect(actual_value)` with assertions:
 
 ### `Example↓`
 
-```
+```js
   const arr = [1, 2, 3]
   expect(arr).toHaveLength(3)
 ```
@@ -133,31 +134,37 @@ Use `expect(actual_value)` with assertions:
 
 ---
 
+## `Test annotations`
+
+`skip()`  Declares a skipped test or test group. Test/s is/are never run.
+
+### `Example↓`
+
+
+```js
+test.skip('description', () => {})
+//or
+describe.skip('description', () => {})
+```
+
+---
+
 ## `Context options`
 
 Use `{}` as the second param for describe and tests func.
 
 ### `Example↓`
 
-```
+```js
 test('description', {}, () => {})
 //or
 describe('description', {}, () => {})
-```
-
-### `Example↓`
-
-```
-describe('description', { skip: true }, () => {})
-//or
-test('description', { skip: true }, () => {})
 ```
 
 ---
 
 | Option Name         | Description                                                             |
 | ------------------- | ----------------------------------------------------------------------- |
-| `{ skip: true }`    | Option for skipping describe/test where it was provided                 |
 | `{ timeout: 2000 }` | Option timeout (in ms) for specifying how long to wait before aborting. |
 |                     | The default timeout is 5 seconds.                                       |
 
@@ -170,7 +177,7 @@ To use it just add `async` keyword before function callback inside `test` block
 
 ### `Example↓`
 
-```
+```js
 test('Wait 1 sec and check', async () => {
   const number = await new Promise((resolve) =>
     setTimeout(() => resolve(1), 1_000)

--- a/src/core/context.mjs
+++ b/src/core/context.mjs
@@ -40,10 +40,6 @@ currentDescribe = makeDescribe('root')
 export const describe = (name, optionsOrBody, body) => {
   const options = typeof optionsOrBody === 'object' ? optionsOrBody : {}
   const actualBody = typeof optionsOrBody === 'function' ? optionsOrBody : body
-  if (options.skip) {
-    printSkippedMsg(name)
-    return
-  }
   const parentDescribe = currentDescribe
   currentDescribe = makeDescribe(name, options)
   actualBody()
@@ -56,10 +52,6 @@ export const describe = (name, optionsOrBody, body) => {
 export const test = (name, optionsOrBody, body) => {
   const options = typeof optionsOrBody === 'object' ? optionsOrBody : {}
   const actualBody = typeof optionsOrBody === 'function' ? optionsOrBody : body
-  if (options.skip) {
-    printSkippedMsg(name)
-    return
-  }
   currentDescribe = {
     ...currentDescribe,
     children: [

--- a/src/core/context.mjs
+++ b/src/core/context.mjs
@@ -69,6 +69,10 @@ export const test = (name, optionsOrBody, body) => {
   }
 }
 
+export const skip = (name) => {
+  printSkippedMsg(name)
+}
+
 export const beforeEach = (body) => {
   currentDescribe = {
     ...currentDescribe,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,6 +3,8 @@
 /**
  * Describe a "suite" with the given title and callback fn containing nested suites.
  *
+ * **Usage**
+ *
  * ```js
  * describe('Unit tests for assertions', () => {
  *  test('Check assertion toBeDefined()', () => {
@@ -16,10 +18,12 @@
  * @param optionsOrBody (Optional) Object with options
  * @param callback A callback that is run immediately when calling describe(name, optionsOrBody, callback)
  */
-export function describe(name: string, optionsOrBody: {}, body: {}): void
+export function describe(name: string, optionsOrBody: {}, body: {}): Options
 
 /**
  * Test a specification or test-case with the given title, test options and callback fn.
+ *
+ * **Usage**
  *
  * ```js
  * test('Check assertion toBeDefined()', () => {
@@ -32,10 +36,45 @@ export function describe(name: string, optionsOrBody: {}, body: {}): void
  * @param optionsOrBody (Optional) Object with options
  * @param callback A callback that is run immediately when calling test(name, optionsOrBody, callback)
  */
-export function test(name: string, optionsOrBody: {}, body: {}): void
+export function test(name: string, optionsOrBody: {}, body: {}): Options
 
+type Options = {
+  /**
+   * Declares a skipped test group.
+   * Tests in the skipped group are never run.
+   * - `describe.skip(title)`
+   * - `describe.skip(title, details, callback)`
+   * - `test.skip(title, callback)`
+   *
+   * **Usage**
+   *
+   * ```js
+   * describe.skip('skipped group', () => {
+   *   test('example', () => {
+   *     // This test will not run
+   *   });
+   * });
+   * ```
+   * or
+   *
+   *  * ```js
+   * describe('example', () => {
+   *   test.skip('skipped test', () => {
+   *     // This test will not run
+   *   });
+   * });
+   * ```
+   *
+   * @param name Test title.
+   * @param optionsOrBody (Optional) Object with options
+   * @param callback A callback that is run immediately when calling test(name, optionsOrBody, callback)
+   */
+  skip(name: string, optionsOrBody: {}, body: {}): void
+}
 /**
  * Execute before each test case.
+ *
+ * **Usage**
  *
  * ```js
  * beforeEach(() => {
@@ -48,6 +87,8 @@ export function beforeEach(body: () => void): void
 /**
  * Execute before all test cases.
  *
+ * **Usage**
+ *
  * ```js
  * beforeAll(() => {
  *  const number = 1
@@ -59,6 +100,8 @@ export function beforeAll(body: () => void): void
 /**
  * Execute after each test case.
  *
+ * **Usage**
+ *
  * ```js
  * afterEach(() => {
  *  const number = 1
@@ -69,6 +112,8 @@ export function afterEach(body: () => void): void
 
 /**
  * Execute after all test cases.
+ *
+ * **Usage**
  *
  * ```js
  * afterAll(() => {
@@ -82,6 +127,8 @@ type Assertions = {
   /**
    * Use .toBeDefined() to check that a variable is not undefined.
    *
+   * **Usage**
+   *
    * ```js
    *  expect(1).toBeDefined()
    * ```
@@ -90,6 +137,8 @@ type Assertions = {
 
   /**
    * Use .toBeUndefined() to check that a variable is undefined.
+   *
+   * **Usage**
    *
    * ```js
    *  expect(undefined).toBeUndefined()
@@ -100,6 +149,8 @@ type Assertions = {
   /**
    * Use .toBeEqual() to compare values are equal (also known as "deep" equality).
    *
+   * **Usage**
+   *
    * ```js
    *  expect('test').toBeEqual('test')
    * ```
@@ -108,6 +159,8 @@ type Assertions = {
 
   /**
    * Use .toBeNotEqual() to compare values are not equal (also known as "deep" equality).
+   *
+   * **Usage**
    *
    * ```js
    *  expect('real').toBeNotEqual('test')
@@ -118,6 +171,8 @@ type Assertions = {
   /**
    * Use .toBeFalsy() to check that a variable is Falsy.
    *
+   * **Usage**
+   *
    * ```js
    *  expect(false).toBeFalsy()
    * ```
@@ -126,6 +181,8 @@ type Assertions = {
 
   /**
    * Use .toBeTruthy() to check that a variable is Truthy.
+   *
+   * **Usage**
    *
    * ```js
    *  expect(true).toBeTruthy()
@@ -136,6 +193,8 @@ type Assertions = {
   /**
    * Use .toBeNull() to check that a variable is Null.
    *
+   * **Usage**
+   *
    * ```js
    *  expect(null).toBeNull()
    * ```
@@ -144,6 +203,8 @@ type Assertions = {
 
   /**
    * Use .toBeNotNull() to check that a variable is not Null.
+   *
+   * **Usage**
    *
    * ```js
    *  expect(1).toBeNotNull()
@@ -154,6 +215,8 @@ type Assertions = {
   /**
    * Use .toHaveLength() to check that an object has a .length property and it is set to a certain numeric value.
    *
+   * **Usage**
+   *
    * ```js
    *  expect([1, 2, 3]).toHaveLength(3)
    * ```
@@ -162,6 +225,8 @@ type Assertions = {
 
   /**
    * Use .toBeNaN() to check that a variable is NaN.
+   *
+   * **Usage**
    *
    * ```js
    *  expect('text').toBeNaN()
@@ -172,6 +237,8 @@ type Assertions = {
   /**
    * Use .toBeGreaterThan() to compare received > expected for number or big integer values.
    *
+   * **Usage**
+   *
    * ```js
    *  expect(5).toBeGreaterThan(4)
    * ```
@@ -181,6 +248,8 @@ type Assertions = {
   /**
    * Use .toBeLessThan() to compare received < expected for number or big integer values.
    *
+   * **Usage**
+   *
    * ```js
    *  expect(3).toBeLessThan(4)
    * ```
@@ -189,6 +258,8 @@ type Assertions = {
 
   /**
    * Use .toContain() when you want to check that an item is in an array or a string.
+   *
+   * **Usage**
    *
    * ```js
    *  expect('test').toContain('st')
@@ -201,6 +272,8 @@ type Assertions = {
   /**
    * Use .toMatch() to check that a string matches a regular expression.
    *
+   * **Usage**
+   *
    * ```js
    *  expect('test').toMatch('st')
    *  expect(['test', 'real']).toMatch('real')
@@ -212,6 +285,8 @@ type Assertions = {
 
 /**
  * Expect gives you access to a number of "matchers" that let you validate different things.
+ *
+ * **Usage**
  *
  * ```js
  *  expect(number).toBeDefined()

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -4,6 +4,8 @@ import { expect as coreExpect } from './core/expect.mjs'
 /**
  * Describe a "suite" with the given title and callback fn containing nested suites.
  *
+ * **Usage**
+ *
  * ```js
  * describe('Unit tests for assertions', () => {
  *  test('Check assertion toBeDefined()', () => {
@@ -21,7 +23,31 @@ export const describe = (name, optionsOrBody, body) =>
   core.describe(name, optionsOrBody, body)
 
 /**
+ * Declares a skipped test group.
+ * Tests in the skipped group are never run.
+ * - `describe.skip(title)`
+ * - `describe.skip(title, details, callback)`
+ *
+ * **Usage**
+ *
+ * ```js
+ * describe.skip('skipped group', () => {
+ *   test('example', () => {
+ *     // This test will not run
+ *   });
+ * });
+ * ```
+ *
+ * @param name Test title.
+ * @param optionsOrBody (Optional) Object with options
+ * @param callback A callback that is run immediately when calling test(name, optionsOrBody, callback)
+ */
+describe.skip = (name) => core.skip(name)
+
+/**
  * Test a specification or test-case with the given title, test options and callback fn.
+ *
+ * **Usage**
  *
  * ```js
  * test('Check assertion toBeDefined()', () => {
@@ -38,7 +64,30 @@ export const test = (name, optionsOrBody, body) =>
   core.test(name, optionsOrBody, body)
 
 /**
+ * Declares a skipped test.
+ * Test is never run.
+ * - `test.skip(title, callback)`
+ *
+ * **Usage**
+ *
+ * ```js
+ * describe('example', () => {
+ *   test.skip('skipped test', () => {
+ *     // This test will not run
+ *   });
+ * });
+ * ```
+ *
+ * @param name Test title.
+ * @param optionsOrBody (Optional) Object with options
+ * @param callback A callback that is run immediately when calling test(name, optionsOrBody, callback)
+ */
+test.skip = (name) => core.skip(name)
+
+/**
  * Execute before each test case.
+ *
+ * **Usage**
  *
  * ```js
  * beforeEach(() => {
@@ -51,6 +100,8 @@ export const beforeEach = (body) => core.beforeEach(body)
 /**
  * Execute before all test cases.
  *
+ * **Usage**
+ *
  * ```js
  * beforeAll(() => {
  *  const number = 1
@@ -62,6 +113,8 @@ export const beforeAll = (body) => core.beforeAll(body)
 /**
  * Execute after each test case.
  *
+ * **Usage**
+ *
  * ```js
  * afterEach(() => {
  *  const number = 1
@@ -72,6 +125,8 @@ export const afterEach = (body) => core.afterEach(body)
 
 /**
  * Execute after all test cases.
+ *
+ * **Usage**
  *
  * ```js
  * afterAll(() => {
@@ -101,6 +156,8 @@ export const afterAll = (body) => core.afterAll(body)
 
 /**
  * Expect gives you access to a number of "matchers" that let you validate different things.
+ *
+ * **Usage**
  *
  * ```js
  *  expect(number).toBeDefined()


### PR DESCRIPTION
- Test `skip` declaration. Moved from: 
  ```
  describe('description', { skip: true }, () => {})
  //or
  test('description', { skip: true }, () => {})
  ```
  to:
  ```
  describe.skip('description', () => {})
  //or
  test.skip('description', () => {})
  ```
- Updated documentation